### PR TITLE
Feature/#39 Github API - Create, Update 작업

### DIFF
--- a/src/github/github.controller.ts
+++ b/src/github/github.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   UseGuards,
   Body,
+  Patch,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -30,6 +31,7 @@ export class GithubController {
     private userService: UserService,
   ) {}
 
+  // ********** Repositories **********
   @Get('repos')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '유저의 깃허브 레포지토리 리스트를 조회한다.' })
@@ -94,6 +96,40 @@ export class GithubController {
       items: createdRepo,
     };
   }
+
+  @Patch('repos/:repoName')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({
+    name: 'repoName',
+    type: String,
+    description: '수정할 repo의 Name',
+  })
+  @ApiOperation({ summary: '유저의 깃허브 레포지토리를 수정한다.' })
+  async updateRepo(@User() user: jwtUserT, @Param() param, @Body() body) {
+    const { id, username } = user;
+    const { repoName } = param;
+    const { updateRepoName, updateDescription, ...otherFields } = body;
+    const { item: githubAccessToken } =
+      await this.userService.getGithubAccessToken({
+        id,
+      });
+    const input = {
+      githubAccessToken,
+      username,
+      repoName,
+      updateRepoName,
+      updateDescription,
+      ...otherFields,
+    };
+    const { item: updateRepo } = await this.githubService.updateRepo(input);
+    return {
+      httpStatus: HttpStatus.OK,
+      message: `유저의 ${updateRepoName} 레포지토리를 성공적으로 수정했습니다`,
+      item: updateRepo,
+    };
+  }
+
+  // ********** Milestones **********
 
   @Get('milestones/:repoName')
   @HttpCode(HttpStatus.OK)
@@ -187,9 +223,53 @@ export class GithubController {
     return {
       httpStatus: HttpStatus.OK,
       message: `유저의 ${repoName} 레포지토리에 ${title} 마일스톤을 성공적으로 생성했습니다`,
-      items: createdMilestone,
+      item: createdMilestone,
     };
   }
+
+  @Patch('milestones/:repoName/:number')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({
+    name: 'repoName',
+    type: String,
+    description: '수정할 마일스톤의 레포지토리 이름',
+  })
+  @ApiParam({
+    name: 'number',
+    type: String,
+    description: '수정할 마일스톤의 번호',
+  })
+  @ApiOperation({
+    summary: '유저의 깃허브 특정 레포지토리의 마일스톤을 수정한다.',
+  })
+  async updateMilestone(@User() user: jwtUserT, @Param() param, @Body() body) {
+    const { id, username } = user;
+    const { repoName, number } = param;
+    const { updateTitle, updateDescription, ...otherFields } = body;
+    const { item: githubAccessToken } =
+      await this.userService.getGithubAccessToken({
+        id,
+      });
+    const input = {
+      githubAccessToken,
+      username,
+      repoName,
+      updateTitle,
+      updateDescription,
+      number,
+      ...otherFields,
+    };
+    const { item: updatedMilestone } = await this.githubService.updateMilestone(
+      input,
+    );
+    return {
+      httpStatus: HttpStatus.OK,
+      message: `유저의 ${repoName} 레포지토리의 ${updateTitle} 마일스톤을 성공적으로 수정했습니다`,
+      item: updatedMilestone,
+    };
+  }
+
+  // ********** Issues **********
 
   @Get('issues/:repoName')
   @ApiParam({
@@ -278,6 +358,46 @@ export class GithubController {
       httpStatus: HttpStatus.OK,
       message: `유저의 ${repoName} 레포지토리에 ${repoName} 이슈를 성공적으로 생성했습니다`,
       items: createdIssue,
+    };
+  }
+
+  @Patch('issues/:repoName/:number')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({
+    name: 'repoName',
+    type: String,
+    description: '수정할 이슈의 레포지토리 이름',
+  })
+  @ApiParam({
+    name: 'number',
+    type: String,
+    description: '수정할 이슈의 번호',
+  })
+  @ApiOperation({
+    summary: '유저의 깃허브 특정 레포지토리의 마일스톤을 수정한다.',
+  })
+  async updateIssues(@User() user: jwtUserT, @Param() param, @Body() body) {
+    const { id, username } = user;
+    const { repoName, number } = param;
+    const { updateTitle, updateDescription, ...otherFields } = body;
+    const { item: githubAccessToken } =
+      await this.userService.getGithubAccessToken({
+        id,
+      });
+    const input = {
+      githubAccessToken,
+      username,
+      repoName,
+      updateTitle,
+      updateDescription,
+      number,
+      ...otherFields,
+    };
+    const { item: updatedIssue } = await this.githubService.updateIssue(input);
+    return {
+      httpStatus: HttpStatus.OK,
+      message: `유저의 ${repoName} 레포지토리의 ${updateTitle} 이슈를 성공적으로 수정했습니다`,
+      item: updatedIssue,
     };
   }
 }

--- a/src/github/github.controller.ts
+++ b/src/github/github.controller.ts
@@ -83,12 +83,18 @@ export class GithubController {
   @ApiOperation({ summary: '유저의 깃허브 레포지토리를 생성한다.' })
   async createRepo(@User() user: jwtUserT, @Body() body) {
     const { id, username } = user;
-    const { repoName, description } = body;
+    const { repoName, description, ...otherFields } = body;
     const { item: githubAccessToken } =
       await this.userService.getGithubAccessToken({
         id,
       });
-    const input = { githubAccessToken, username, repoName, description };
+    const input = {
+      githubAccessToken,
+      username,
+      repoName,
+      description,
+      ...otherFields,
+    };
     const { item: createdRepo } = await this.githubService.createRepo(input);
     return {
       httpStatus: HttpStatus.OK,
@@ -211,12 +217,19 @@ export class GithubController {
   async createMilestone(@User() user: jwtUserT, @Param() param, @Body() body) {
     const { id, username } = user;
     const { repoName } = param;
-    const { title, description } = body;
+    const { title, description, ...otherFields } = body;
     const { item: githubAccessToken } =
       await this.userService.getGithubAccessToken({
         id,
       });
-    const input = { githubAccessToken, username, repoName, title, description };
+    const input = {
+      githubAccessToken,
+      username,
+      repoName,
+      title,
+      description,
+      ...otherFields,
+    };
     const { item: createdMilestone } = await this.githubService.createMilestone(
       input,
     );
@@ -347,12 +360,19 @@ export class GithubController {
   async createIssue(@User() user: jwtUserT, @Param() param, @Body() body) {
     const { id, username } = user;
     const { repoName } = param;
-    const { title, description } = body;
+    const { title, description, ...otherFields } = body;
     const { item: githubAccessToken } =
       await this.userService.getGithubAccessToken({
         id,
       });
-    const input = { githubAccessToken, username, repoName, title, description };
+    const input = {
+      githubAccessToken,
+      username,
+      repoName,
+      title,
+      description,
+      ...otherFields,
+    };
     const { item: createdIssue } = await this.githubService.createIssue(input);
     return {
       httpStatus: HttpStatus.OK,

--- a/src/github/github.service.ts
+++ b/src/github/github.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-// import { ServiceResultDto } from 'src/common/common.dto';
 import { Octokit } from 'octokit';
 import { REQUEST_INFO } from 'src/common/request-url';
 import { UserService } from 'src/user/user.service';
@@ -25,8 +24,10 @@ export class GithubService {
   constructor(private userService: UserService) {}
   // ********** github **********
 
+  // ********** Repositories **********
   /**
-   * @param input githubAccessToken, username
+   * @param input.githubAccessToken - GitHub 토큰
+   * @param input.username - GitHub 사용자의 이름
    */
   async findRepos(input) {
     const { githubAccessToken, username } = input;
@@ -41,7 +42,10 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, username, repoName
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - 찾으려는 Repo의 이름
    */
   async findOneRepo(input) {
     const { githubAccessToken, username, repoName } = input;
@@ -55,13 +59,17 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, repoName, description
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.repoName - 생성하려는 Repo의 이름
+   * @param {string} input.description - 생성하려는 Repo의 설명
+   * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
    */
   async createRepo(input) {
-    const { githubAccessToken, repoName, description } = input;
+    const { githubAccessToken, repoName, description, ...otherFields } = input;
     const createdRepo = await callGitHubApi(
       `Post /user/repos`,
-      { repoName, description },
+      { repoName, description, ...otherFields },
       githubAccessToken,
     );
 
@@ -69,7 +77,39 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, username, repoName
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - 수정할 리포의 이름
+   * @param {string} input.updateRepoName - 수정하려는 리포의 이름
+   * @param {string} input.updateDescription - 수정하려는 리포의 설명
+   * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
+   */
+  async updateRepo(input) {
+    const {
+      githubAccessToken,
+      username,
+      repoName,
+      updateRepoName,
+      updateDescription,
+      ...otherFields
+    } = input;
+    const updatedRepo = await callGitHubApi(
+      `PATCH /repos/${username}/${repoName}`,
+      { name: updateRepoName, description: updateDescription, ...otherFields },
+      githubAccessToken,
+    );
+
+    return { item: updatedRepo };
+  }
+
+  // ********** Milestones **********
+
+  /**
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - Milestion이 위치한 Repo의 이름
    */
   async findMilestones(input) {
     // findSprints를 하기보단 github용어에 맞추어서 변수명 작성
@@ -86,7 +126,11 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, username, repoName, number
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - Milestone이 위치한 리포의 이름
+   * @param {string} input.number - 찾으려는 Milestone의 number
    */
   async findOneMilestone(input) {
     const { githubAccessToken, username, repoName, number } = input;
@@ -101,7 +145,13 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, username, repoName, title, description
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - 수정할 Repo의 이름
+   * @param {string} input.title - 생성하려는 Milestone 이름
+   * @param {string} input.description - 생성하려는 Milestone 설명
+   * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
    */
   async createMilestone(input) {
     const { githubAccessToken, username, repoName, title, description } = input;
@@ -115,7 +165,41 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, username, repoName
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - Milestone이 위치한 Repo의 이름
+   * @param {string} input.updateTitle - 수정하려는 Milestone의 이름
+   * @param {string} input.updateDescription - 해당값으로 Milestone 설명 수정
+   * @param {string} input.number - 수정하려는 Milestone의 Number
+   * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
+   */
+  async updateMilestone(input) {
+    const {
+      githubAccessToken,
+      username,
+      repoName,
+      updateTitle,
+      updateDescription,
+      number,
+      ...otherFields
+    } = input;
+    const updatedMilestone = await callGitHubApi(
+      `PATCH /repos/${username}/${repoName}/milestones/${number}`,
+      { title: updateTitle, description: updateDescription, ...otherFields },
+      githubAccessToken,
+    );
+
+    return { item: updatedMilestone };
+  }
+
+  // ********** Issues **********
+
+  /**
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - 찾으려는 Issue가 위치한 Repo의 이름
    */
   async findIssues(input) {
     const { githubAccessToken, username, repoName } = input;
@@ -130,7 +214,12 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, username, repoName, number
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - 찾으려는 Issue가 위치한 Repo의 이름
+   * @param {string} input.number - 찾으려는 Issue의 Number
+   * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
    */
   async findOneIssue(input) {
     const { githubAccessToken, username, repoName, number } = input;
@@ -145,17 +234,59 @@ export class GithubService {
   }
 
   /**
-   * @param input githubAccessToken, username, repoName, title, description
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - 생성하려는 Issue가 위치한 Repo의 이름
+   * @param {string} input.title - 생성하려는 Issue의 이름
+   * @param {string} input.description - 생성하려는 Issue의 설명
+   * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
    */
   async createIssue(input) {
-    const { githubAccessToken, username, repoName, title, description } = input;
+    const {
+      githubAccessToken,
+      username,
+      repoName,
+      title,
+      description,
+      ...otherFields
+    } = input;
 
     const createdIssue = await callGitHubApi(
       `Post /repos/${username}/${repoName}/issues`,
-      { title, body: description },
+      { title, body: description, ...otherFields },
       githubAccessToken,
     );
 
     return { item: createdIssue };
+  }
+
+  /**
+   * @param {Object} input
+   * @param {string} input.githubAccessToken - GitHub 토큰
+   * @param {string} input.username - GitHub 사용자의 이름
+   * @param {string} input.repoName - 수정하려는 Issue가 위치한 Repo의 이름
+   * @param {string} input.updateTitle - 해당 값으로 Issue 제목 수정
+   * @param {string} input.updateDescription - 해당 값으로 Issue 설명 수정
+   * @param {string} input.number - 수정하려는 Issue의 Number
+   * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
+   */
+  async updateIssue(input) {
+    const {
+      githubAccessToken,
+      username,
+      repoName,
+      updateTitle,
+      updateDescription,
+      number,
+      ...otherFields
+    } = input;
+    const updatedIssue = await callGitHubApi(
+      `PATCH /repos/${username}/${repoName}/issues/${number}`,
+      { title: updateTitle, description: updateDescription, ...otherFields },
+      githubAccessToken,
+    );
+
+    return { item: updatedIssue };
   }
 }

--- a/src/github/github.service.ts
+++ b/src/github/github.service.ts
@@ -7,7 +7,6 @@ import { UserService } from 'src/user/user.service';
 async function callGitHubApi(endpoint: string, params: object, token: string) {
   try {
     const octokit = new Octokit({ auth: token });
-
     const { data: result } = await octokit.request(endpoint, {
       ...params,
       headers: {
@@ -26,14 +25,9 @@ export class GithubService {
   constructor(private userService: UserService) {}
   // ********** github **********
 
-  // UserService에서 처리하는게 좋을 경우 제거
-  // async getGithubAccessToken(input) {
-  //   const { id } = input;
-  //   const { item: user } = await this.userService.findOne({ id });
-
-  //   return { item: user?.githubAccessToken };
-  // }
-
+  /**
+   * @param input githubAccessToken, username
+   */
   async findRepos(input) {
     const { githubAccessToken, username } = input;
 
@@ -46,11 +40,13 @@ export class GithubService {
     return { items: repos };
   }
 
+  /**
+   * @param input githubAccessToken, username, repoName
+   */
   async findOneRepo(input) {
-    const { githubAccessToken, username, name } = input;
-
+    const { githubAccessToken, username, repoName } = input;
     const repo = await callGitHubApi(
-      `GET /repos/${username}/${name}`,
+      `GET /repos/${username}/${repoName}`,
       username,
       githubAccessToken,
     );
@@ -58,29 +54,30 @@ export class GithubService {
     return { item: repo };
   }
 
-  // async createRepo(input) {
-  //   const { githubAccessToken, org } = input;
-  //   const octokit = new Octokit({
-  //     auth: githubAccessToken,
-  //   });
+  /**
+   * @param input githubAccessToken, repoName, description
+   */
+  async createRepo(input) {
+    const { githubAccessToken, repoName, description } = input;
+    const createdRepo = await callGitHubApi(
+      `Post /user/repos`,
+      { repoName, description },
+      githubAccessToken,
+    );
 
-  //   const { data: createdRepo } = await octokit.request(
-  //     `Post /orgs/${org}/repos`,
-  //     {
-  //       ...input,
-  //     },
-  //   );
+    return { item: createdRepo };
+  }
 
-  //   return { item: createdRepo };
-  // }
-
+  /**
+   * @param input githubAccessToken, username, repoName
+   */
   async findMilestones(input) {
     // findSprints를 하기보단 github용어에 맞추어서 변수명 작성
 
-    const { githubAccessToken, username, name } = input;
+    const { githubAccessToken, username, repoName } = input;
 
     const milestones = await callGitHubApi(
-      `GET /repos/${username}/${name}/milestones`,
+      `GET /repos/${username}/${repoName}/milestones`,
       { owner: username },
       githubAccessToken,
     );
@@ -88,6 +85,9 @@ export class GithubService {
     return { items: milestones };
   }
 
+  /**
+   * @param input githubAccessToken, username, repoName, number
+   */
   async findOneMilestone(input) {
     const { githubAccessToken, username, repoName, number } = input;
 
@@ -100,23 +100,28 @@ export class GithubService {
     return { item: milestone };
   }
 
-  // async createMilestone(input) {
-  //   const { githubAccessToken, username, repoName } = input;
+  /**
+   * @param input githubAccessToken, username, repoName, title, description
+   */
+  async createMilestone(input) {
+    const { githubAccessToken, username, repoName, title, description } = input;
+    const createdMilestone = await callGitHubApi(
+      `Post /repos/${username}/${repoName}/milestones`,
+      { title, description },
+      githubAccessToken,
+    );
 
-  //   const createdMilestone = await callGitHubApi(
-  //     `Post /repos/${username}/${repoName}/milestones}`,
-  //     { owner: username },
-  //     githubAccessToken,
-  //   );
+    return { item: createdMilestone };
+  }
 
-  //   return { item: createdMilestone };
-  // }
-
+  /**
+   * @param input githubAccessToken, username, repoName
+   */
   async findIssues(input) {
-    const { githubAccessToken, username, name } = input;
+    const { githubAccessToken, username, repoName } = input;
 
     const issues = await callGitHubApi(
-      `GET /repos/${username}/${name}/issues`,
+      `GET /repos/${username}/${repoName}/issues`,
       { owner: username },
       githubAccessToken,
     );
@@ -124,6 +129,9 @@ export class GithubService {
     return { items: issues };
   }
 
+  /**
+   * @param input githubAccessToken, username, repoName, number
+   */
   async findOneIssue(input) {
     const { githubAccessToken, username, repoName, number } = input;
 
@@ -136,15 +144,18 @@ export class GithubService {
     return { item: issue };
   }
 
-  // async createIssue(input) {
-  //   const { githubAccessToken, username, repoName } = input;
+  /**
+   * @param input githubAccessToken, username, repoName, title, description
+   */
+  async createIssue(input) {
+    const { githubAccessToken, username, repoName, title, description } = input;
 
-  //   const createdIssue = await callGitHubApi(
-  //     `Post /repos/${username}/${repoName}/issues}`,
-  //     { owner: username },
-  //     githubAccessToken,
-  //   );
+    const createdIssue = await callGitHubApi(
+      `Post /repos/${username}/${repoName}/issues`,
+      { title, body: description },
+      githubAccessToken,
+    );
 
-  //   return { item: createdIssue };
-  // }
+    return { item: createdIssue };
+  }
 }

--- a/src/github/github.service.ts
+++ b/src/github/github.service.ts
@@ -154,10 +154,17 @@ export class GithubService {
    * @param {string} input.otherFields - 그 외에 들어올 수 있는 값들
    */
   async createMilestone(input) {
-    const { githubAccessToken, username, repoName, title, description } = input;
+    const {
+      githubAccessToken,
+      username,
+      repoName,
+      title,
+      description,
+      ...otherFields
+    } = input;
     const createdMilestone = await callGitHubApi(
       `Post /repos/${username}/${repoName}/milestones`,
-      { title, description },
+      { title, description, ...otherFields },
       githubAccessToken,
     );
 


### PR DESCRIPTION
1. Create, Update시 기본적으로는 제목, 설명만을 수정하도록 함.
2. private설정이나, has_issue 등의 값들도 body로 받으면 수정이 될 수 있도록 otherField 추가
3. @param 값으로 어떤 인자들을 받고 있는지 설명 추가
4. otherField에 어떤 값들이 추가가 될 수 있는지 추가 고려중 ( 너무 많아질까봐 우선 누락 )
5. Create, Update API  정상동작 확인 완료